### PR TITLE
Update success payment check.

### DIFF
--- a/API.md
+++ b/API.md
@@ -27,6 +27,7 @@
 | Visibility | Function |
 |:-----------|:---------|
 | public | <strong>getResponseCode()</strong> : <em>string</em><br /><em>Get response code - value of 'RC' field</em> |
+| public | <strong>getAction()</strong> : <em>string</em><br /><em>Get action - value of 'ACTION' field</em> |
 | public | <strong>isSuccessful()</strong> : <em>boolean</em><br /><em>Is success payment?</em> |
 
 *This class extends [\VenelinIliev\Borica3ds\Response](#class-venelinilievborica3dsresponse-abstract)*

--- a/src/SaleResponse.php
+++ b/src/SaleResponse.php
@@ -26,7 +26,8 @@ class SaleResponse extends Response implements ResponseInterface
      */
     public function isSuccessful()
     {
-        return $this->getResponseCode() === '00';
+        return $this->getResponseCode() === '00' &&
+            $this->getAction() === '0';
     }
 
     /**
@@ -38,5 +39,16 @@ class SaleResponse extends Response implements ResponseInterface
     public function getResponseCode()
     {
         return $this->getVerifiedData('RC');
+    }
+
+    /**
+     * Get action - value of 'ACTION' field
+     *
+     * @return string
+     * @throws Exceptions\SignatureException|ParameterValidationException|DataMissingException
+     */
+    public function getAction()
+    {
+        return $this->getVerifiedData('ACTION');
     }
 }


### PR DESCRIPTION
Add a check for the 'Action' field in SaleResponse->isSuccessful(). Implementing #12 

I was not able to generate the correct test for failed payment because of "ACTION" value. The reason is that I cant generate the signature for this response with the Terminal and Merchant identifiers in in the repo. I made several tests locally and it works as expected.

