### PR TITLE
Prepare for adoption of EUR

### DIFF
--- a/src/PreAuthorisationCompletionRequest.php
+++ b/src/PreAuthorisationCompletionRequest.php
@@ -18,6 +18,7 @@ class PreAuthorisationCompletionRequest extends Request implements RequestInterf
      */
     public function __construct()
     {
+        parent::__construct();
         $this->setTransactionType(TransactionType::PRE_AUTHORISATION_COMPLETION());
         $this->requestType = new Direct();
     }

--- a/src/PreAuthorisationRequest.php
+++ b/src/PreAuthorisationRequest.php
@@ -22,6 +22,7 @@ class PreAuthorisationRequest extends Request implements RequestInterface
      */
     public function __construct()
     {
+        parent::__construct();
         $this->setTransactionType(TransactionType::PRE_AUTHORISATION());
         $this->setRequestType(new HtmlForm());
     }

--- a/src/PreAuthorisationReversalRequest.php
+++ b/src/PreAuthorisationReversalRequest.php
@@ -18,6 +18,7 @@ class PreAuthorisationReversalRequest extends Request implements RequestInterfac
      */
     public function __construct()
     {
+        parent::__construct();
         $this->setTransactionType(TransactionType::PRE_AUTHORISATION_REVERSAL());
         $this->requestType = new Direct();
     }

--- a/src/Request.php
+++ b/src/Request.php
@@ -110,6 +110,16 @@ abstract class Request extends Base
     protected $requestType;
 
     /**
+     * @throws ParameterValidationException
+     */
+    public function __construct()
+    {
+        if (date('Y') > 2025) {
+            $this->setCurrency('EUR');
+        }
+    }
+
+    /**
      * Get description
      *
      * @return string

--- a/src/ReversalRequest.php
+++ b/src/ReversalRequest.php
@@ -18,6 +18,7 @@ class ReversalRequest extends Request implements RequestInterface
      */
     public function __construct()
     {
+        parent::__construct();
         $this->setTransactionType(TransactionType::REVERSAL());
         $this->requestType = new Direct();
     }

--- a/src/SaleRequest.php
+++ b/src/SaleRequest.php
@@ -22,6 +22,7 @@ class SaleRequest extends Request implements RequestInterface
      */
     public function __construct()
     {
+        parent::__construct();
         $this->setTransactionType(TransactionType::SALE());
         $this->setRequestType(new HtmlForm());
     }

--- a/src/StatusCheckRequest.php
+++ b/src/StatusCheckRequest.php
@@ -26,6 +26,7 @@ class StatusCheckRequest extends Request implements RequestInterface
      */
     public function __construct()
     {
+        parent::__construct();
         $this->setTransactionType(TransactionType::TRANSACTION_STATUS_CHECK());
         $this->setRequestType(new Direct());
     }


### PR DESCRIPTION
Bulgaria adopt the EUR from 01.01.2026 00:00. This is the reason why Borica automatically decline all request in BGN currency after that time. So the default currency of all requests to Borica must be in EUR. 